### PR TITLE
Remove _cloneRepo from TaskRunner

### DIFF
--- a/beaver_core/lib/src/task_runner.dart
+++ b/beaver_core/lib/src/task_runner.dart
@@ -10,15 +10,7 @@ class TaskRunner {
   TaskRunner(this.context, /* Task|ExecuteFunc */ task)
       : this.task = task is Task ? task : new Task.fromFunc(task);
 
-  Future<Null> _cloneRepo() async {
-    // FIXME: Support the repository types other than git.
-    final repo = context.config['repository']['location'];
-    await new GitTask(['clone', repo]).execute(context);
-  }
-
   Future<TaskRunResult> run() async {
-    await _cloneRepo();
-
     var status = TaskStatus.Success;
     final logger = context.logger;
     try {


### PR DESCRIPTION
Specified task by runBeaver can be not related to the specific repository.