### PR TITLE
Make 'result' command able to show multiple results.

### DIFF
--- a/beaver_api/lib/src/formatter/html_formatter.dart
+++ b/beaver_api/lib/src/formatter/html_formatter.dart
@@ -8,15 +8,19 @@ class HtmlFormatter implements Formatter {
   @override
   String get type => 'html';
 
-  final TriggerResult _result;
+  final List<TriggerResult> _results;
 
-  HtmlFormatter(this._result);
+  HtmlFormatter(this._results);
 
   void _buildTable(XmlBuilder builder) {
     builder.element('table', nest: () {
       builder.attribute('class', 'pure-table');
       _buildTableHeader(builder);
-      _buildTableBody(builder);
+      builder.element('tbody', nest: () {
+        _results.forEach((result) {
+          _buildTableBodyRow(result, builder);
+        });
+      });
     });
   }
 
@@ -40,29 +44,27 @@ class HtmlFormatter implements Formatter {
     });
   }
 
-  void _buildTableBody(XmlBuilder builder) {
-    builder.element('tbody', nest: () {
-      builder.element('tr', nest: () {
-        builder.element('td', nest: () {
-          builder.text(_result.buildNumber.toString());
-        });
-        builder.element('td', nest: () {
-          builder.text(_result.taskInstanceRunResult.status ==
-              TaskInstanceStatus.success ? "Success" : "Failure");
-        });
-        builder.element('td', nest: () {
-          builder.text(_result.taskInstanceRunResult.taskRunResult.status ==
-              TaskStatus.Success ? "Success" : "Failure");
-        });
-        builder.element('td', nest: () {
-          builder.text(_result.parsedTrigger.event);
-        });
-        builder.element('td', nest: () {
-          builder.text(_result.parsedTrigger.url);
-        });
-        builder.element('td', nest: () {
-          builder.text(_result.taskInstanceRunResult.taskRunResult.log);
-        });
+  void _buildTableBodyRow(TriggerResult result, XmlBuilder builder) {
+    builder.element('tr', nest: () {
+      builder.element('td', nest: () {
+        builder.text(result.buildNumber.toString());
+      });
+      builder.element('td', nest: () {
+        builder.text(result.taskInstanceRunResult.status ==
+            TaskInstanceStatus.success ? "Success" : "Failure");
+      });
+      builder.element('td', nest: () {
+        builder.text(result.taskInstanceRunResult.taskRunResult.status ==
+            TaskStatus.Success ? "Success" : "Failure");
+      });
+      builder.element('td', nest: () {
+        builder.text(result.parsedTrigger.event);
+      });
+      builder.element('td', nest: () {
+        builder.text(result.parsedTrigger.url);
+      });
+      builder.element('td', nest: () {
+        builder.text(result.taskInstanceRunResult.taskRunResult.log);
       });
     });
   }
@@ -79,7 +81,8 @@ class HtmlFormatter implements Formatter {
       });
       builder.element('body', nest: () {
         builder.element('h1', nest: () {
-          builder.text('${_result.project.name} (${_result.project.id})');
+          builder
+              .text('${_results[0].project.name} (${_results[0].project.id})');
         });
         _buildTable(builder);
       });

--- a/beaver_api/lib/src/formatter/text_formatter.dart
+++ b/beaver_api/lib/src/formatter/text_formatter.dart
@@ -7,32 +7,36 @@ class TextFormatter implements Formatter {
   @override
   String get type => 'text';
 
-  final TriggerResult _result;
+  final List<TriggerResult> _results;
 
-  TextFormatter(this._result);
+  TextFormatter(this._results);
 
-  String toText() {
-    final buffer = new StringBuffer();
-
-    buffer.writeln("${_result.project.name} (${_result.project.id})");
-
+  void _writeResult(TriggerResult result, StringBuffer buffer) {
     final items = {
-      "Build Number": _result.buildNumber.toString(),
-      "TaskInstance Status": _result.taskInstanceRunResult.status ==
+      "Build Number": result.buildNumber.toString(),
+      "TaskInstance Status": result.taskInstanceRunResult.status ==
           TaskInstanceStatus.success ? "Success" : "Failure",
-      "Task Status": _result.taskInstanceRunResult.taskRunResult.status ==
+      "Task Status": result.taskInstanceRunResult.taskRunResult.status ==
           TaskStatus.Success ? "Success" : "Failure",
-      "Trigger Event": _result.parsedTrigger.event,
-      "Trigger URL": _result.parsedTrigger.url,
-      "Log": _result.taskInstanceRunResult.taskRunResult.log,
+      "Trigger Event": result.parsedTrigger.event,
+      "Trigger URL": result.parsedTrigger.url,
+      "Log": result.taskInstanceRunResult.taskRunResult.log,
     };
-
     final longestKeyLength = items.keys.fold(0, (num max, String keyString) {
       return keyString.length > max ? keyString.length : max;
     });
     items.forEach((String itemName, String itemContent) {
       buffer.writeln(
           " - ${itemName.padRight(longestKeyLength + 1)}: ${itemContent}");
+    });
+  }
+
+  String toText() {
+    final buffer = new StringBuffer();
+
+    buffer.writeln("${_results[0].project.name} (${_results[0].project.id})");
+    _results.forEach((result) {
+      _writeResult(result, buffer);
     });
 
     return buffer.toString();

--- a/beaver_cli/lib/src/command/result_command.dart
+++ b/beaver_cli/lib/src/command/result_command.dart
@@ -63,6 +63,11 @@ class ResultCommand extends Command {
         defaultsTo: 'text',
         allowed: ['text', 'html'],
         help: 'The result format.');
+
+    argParser.addOption('count',
+        abbr: 'n',
+        defaultsTo: '1',
+        help: 'Number of results to output.');
   }
 
   String get api => '/api/result';
@@ -74,7 +79,8 @@ class ResultCommand extends Command {
     final data = JSON.encode({
       'id': argResults['project-id'],
       'build_number': argResults['build-number'],
-      'format': argResults['format']
+      'format': argResults['format'],
+      'count': argResults['count']
     });
 
     final httpClient = new HttpClient();


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/9711879/18680553/30f5b504-7f9f-11e6-9d53-a5db59ede494.png)
![image](https://cloud.githubusercontent.com/assets/9711879/18680562/392d8512-7f9f-11e6-9935-0b429be6a3d5.png)

CLI에는 -n 옵션 추가해서 정수를 넘겨줄 수 있고(default 1), 주어진 빌드넘버로 부터 n개 만큼의 result를 출력하도록 수정했습니다.

buildNumber가 3, n이 2면 (3, 2)의 결과를 보여줍니다.

스크린샷 찍을 때에도 3, 2를 넣었는데 Build Number가 둘 다 3으로 나왔는데, 추적해 보니 LocalMachineStorageService에서 세이브 할 때 project를 얕은 복사하면서 발생하는 문제로 보입니다. 객체를 deep copy 하는 무난한 방법을 찾지 못해서 아직 수정하진 못했습니다.