### PR TITLE
Impl datastore

### DIFF
--- a/beaver_api/lib/src/beaver_api_base.dart
+++ b/beaver_api/lib/src/beaver_api_base.dart
@@ -40,6 +40,10 @@ Future<Map<String, Object>> apiHandler(
 // FIXME: Don't use StorageServiceType.localMachine here.
 final _beaverStore = new BeaverStore(StorageServiceType.localMachine);
 
+Future<Null> initApiHandler() async {
+  await _beaverStore.init();
+}
+
 /// Set new project. Returns the id of the registered project.
 Future<String> _registerProject(String projectName, String config) async {
   final projectId = await _beaverStore.setNewProject(projectName);

--- a/beaver_frontend_gae/bin/server.dart
+++ b/beaver_frontend_gae/bin/server.dart
@@ -9,6 +9,7 @@ import 'package:shelf/shelf_io.dart' as shelf_io;
 import 'package:shelf_route/shelf_route.dart' as shelf_route;
 
 main() async {
+  await initApiHandler();
   final router = shelf_route.router()
     ..add('/api', ['POST'], _apiHandler, exactMatch: false)
     ..add('/github', ['POST'], _githubTriggerHandler, exactMatch: false);

--- a/beaver_store/lib/src/beaver_store_base.dart
+++ b/beaver_store/lib/src/beaver_store_base.dart
@@ -14,6 +14,10 @@ class BeaverStore {
   BeaverStore(StorageServiceType storageServiceType)
       : _storageService = getStorageService(storageServiceType);
 
+  Future<Null> init() async {
+    await _storageService.init(new Map());
+  }
+
   /// Return the id of Project.
   Future<String> setNewProject(String name) {
     return _storageService.saveProject(new Project(name));

--- a/beaver_store/lib/src/storage_service.dart
+++ b/beaver_store/lib/src/storage_service.dart
@@ -20,6 +20,8 @@ abstract class StorageService {
   Future<TriggerResult> loadResult(String projectId, int buildNumber);
   Future<bool> saveResult(
       String projectId, int buildNumber, TriggerResult result);
+
+  Future<Null> init(Map<String, String> config);
 }
 
 final Map<StorageServiceType, CreateStorageService> _map = {

--- a/beaver_store/lib/src/storage_service/gcloud_model/build.dart
+++ b/beaver_store/lib/src/storage_service/gcloud_model/build.dart
@@ -1,0 +1,40 @@
+import 'package:gcloud/db.dart';
+
+@Kind()
+class BeaverBuild extends Model {
+  @StringProperty()
+  String projectId;
+
+  @IntProperty()
+  int number;
+
+  @StringProperty()
+  String triggerData;
+
+  @StringProperty()
+  String triggerType;
+
+  @StringProperty()
+  String triggerHeaders;
+
+  @StringProperty()
+  String triggerEvent;
+
+  @StringProperty()
+  String triggerUrl;
+
+  @StringProperty()
+  String taskInstance;
+
+  @StringProperty()
+  String taskInstanceStatus;
+
+  @StringProperty()
+  String taskStatus;
+
+  @StringProperty()
+  String taskConfig;
+
+  @StringProperty()
+  String log;
+}

--- a/beaver_store/lib/src/storage_service/gcloud_model/project.dart
+++ b/beaver_store/lib/src/storage_service/gcloud_model/project.dart
@@ -2,10 +2,6 @@ import 'package:gcloud/db.dart';
 
 @Kind()
 class BeaverProject extends Model {
-  // FIXME: id could be used.
-  @StringProperty()
-  String projectId;
-
   @StringProperty()
   String name;
 

--- a/beaver_store/lib/src/storage_service/gcloud_model/project.dart
+++ b/beaver_store/lib/src/storage_service/gcloud_model/project.dart
@@ -1,0 +1,17 @@
+import 'package:gcloud/db.dart';
+
+@Kind()
+class BeaverProject extends Model {
+  // FIXME: id could be used.
+  @StringProperty()
+  String projectId;
+
+  @StringProperty()
+  String name;
+
+  @StringProperty()
+  String config;
+
+  @IntProperty()
+  int buildNumber;
+}

--- a/beaver_store/lib/src/storage_service/gcloud_storage_service.dart
+++ b/beaver_store/lib/src/storage_service/gcloud_storage_service.dart
@@ -46,4 +46,7 @@ class GCloudStorageService implements StorageService {
   Future<bool> setBuildNumber(String projectId, int buildNumber) {
     // TODO: implement setBuildNumber
   }
+
+  @override
+  Future<Null> init(Map<String, String> config) => null;
 }

--- a/beaver_store/lib/src/storage_service/gcloud_storage_service.dart
+++ b/beaver_store/lib/src/storage_service/gcloud_storage_service.dart
@@ -1,11 +1,14 @@
 import 'dart:async';
 
+import 'package:beaver_gcloud/src/gcloud_mixin.dart';
 import 'package:beaver_trigger_handler/beaver_trigger_handler.dart';
 
 import '../model/project.dart';
 import '../storage_service.dart';
 
-class GCloudStorageService implements StorageService {
+class GCloudStorageService extends Object
+    with GCloudMixin
+    implements StorageService {
   @override
   Future<String> loadConfigFile(String projectId) {
     // TODO: implement loadConfigFile
@@ -48,5 +51,5 @@ class GCloudStorageService implements StorageService {
   }
 
   @override
-  Future<Null> init(Map<String, String> config) => null;
+  Future<Null> init(Map<String, String> config) => super.init(config);
 }

--- a/beaver_store/lib/src/storage_service/gcloud_storage_service.dart
+++ b/beaver_store/lib/src/storage_service/gcloud_storage_service.dart
@@ -68,13 +68,16 @@ class GCloudStorageService extends Object
   }
 
   @override
-  Future<int> getBuildNumber(String projectId) {
-    // TODO: implement getBuildNumber
+  Future<int> getBuildNumber(String projectId) async {
+    return (await _queryProjectModel(projectId)).buildNumber;
   }
 
   @override
-  Future<bool> setBuildNumber(String projectId, int buildNumber) {
-    // TODO: implement setBuildNumber
+  Future<bool> setBuildNumber(String projectId, int buildNumber) async {
+    final projectModel = await _queryProjectModel(projectId);
+    projectModel.buildNumber = buildNumber;
+    await db.commit(inserts: [projectModel]);
+    return true;
   }
 
   @override

--- a/beaver_store/lib/src/storage_service/gcloud_storage_service.dart
+++ b/beaver_store/lib/src/storage_service/gcloud_storage_service.dart
@@ -1,22 +1,32 @@
 import 'dart:async';
 
 import 'package:beaver_gcloud/src/gcloud_mixin.dart';
+import 'package:beaver_store/src/model/config.dart';
 import 'package:beaver_trigger_handler/beaver_trigger_handler.dart';
+import 'package:gcloud/datastore.dart' as datastore;
 
 import '../model/project.dart';
 import '../storage_service.dart';
+import 'gcloud_model/project.dart';
 
 class GCloudStorageService extends Object
     with GCloudMixin
     implements StorageService {
-  @override
-  Future<String> loadConfigFile(String projectId) {
-    // TODO: implement loadConfigFile
+  Future<String> _allocateProjectId() async {
+    final keyElement = new datastore.KeyElement('BeaverProject', null);
+    final key = new datastore.Key([keyElement]);
+    final populatedKey = (await db.datastore.allocateIds([key])).first;
+    return populatedKey.elements.first.id.toString();
+  }
+
+  Future<BeaverProject> _queryProjectModel(String projectId) async {
+    final query = db.query(BeaverProject)..filter('projectId =', projectId);
+    return query.run().first;
   }
 
   @override
-  Future<Project> loadProject(String projectId) {
-    // TODO: implement loadProject
+  Future<String> loadConfigFile(String projectId) {
+    // TODO: implement loadConfigFile
   }
 
   @override
@@ -25,8 +35,25 @@ class GCloudStorageService extends Object
   }
 
   @override
-  Future<String> saveProject(Project project) {
-    // TODO: implement saveProject
+  Future<Project> loadProject(String projectId) async {
+    final projectModel = await _queryProjectModel(projectId);
+    return new Project(projectModel.name)
+      ..id = projectModel.projectId
+      ..config = new YamlConfig(projectModel.config);
+  }
+
+  @override
+  Future<String> saveProject(Project project) async {
+    final projectModel = project.id == null
+        ? (new BeaverProject()
+          ..projectId = await _allocateProjectId()
+          ..buildNumber = 0)
+        : await _queryProjectModel(project.id);
+    projectModel
+      ..name = project.name
+      ..config = project.config.toString();
+    await db.commit(inserts: [projectModel]);
+    return projectModel.projectId;
   }
 
   @override

--- a/beaver_store/lib/src/storage_service/local_machine_storage_service.dart
+++ b/beaver_store/lib/src/storage_service/local_machine_storage_service.dart
@@ -79,4 +79,7 @@ class LocalMachineStorageService implements StorageService {
     _buildNumberMap[projectId] = buildNumber;
     return true;
   }
+
+  @override
+  Future<Null> init(Map<String, String> config) => null;
 }

--- a/beaver_store/pubspec.yaml
+++ b/beaver_store/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     path: ../beaver_task
   beaver_trigger_handler:
     path: ../beaver_trigger_handler
+  gcloud: '>=0.3.0 <0.4.0'
   path: '>=1.3.9 <1.4.0'
   quiver_collection: '>=1.0.0 <1.1.0'
   uuid: '>=0.5.3 <0.6.0'

--- a/beaver_task/lib/src/run.dart
+++ b/beaver_task/lib/src/run.dart
@@ -18,7 +18,7 @@ class TaskRunResult {
 
   final String log;
 
-  TaskRunResult._internal(this.config, this.status, this.log);
+  TaskRunResult(this.config, this.status, this.log);
 }
 
 Future<TaskRunResult> _runTask(
@@ -35,7 +35,7 @@ Future<TaskRunResult> _runTask(
     logger.error(e);
     status = TaskStatus.Failure;
   }
-  return new TaskRunResult._internal(context.config, status, logger.toString());
+  return new TaskRunResult(context.config, status, logger.toString());
 }
 
 String taskStatusToString(TaskStatus status) {

--- a/beaver_trigger_handler/lib/src/trigger_handler.dart
+++ b/beaver_trigger_handler/lib/src/trigger_handler.dart
@@ -18,10 +18,11 @@ Logger _createLogger() {
   return logger;
 }
 
-Context _createContext() {
+Future<Context> _createContext() async {
   final logger = _createLogger();
   // FIXME: Don't hardcode.
   final beaverStore = new BeaverStore(StorageServiceType.localMachine);
+  await beaverStore.init();
   return new Context(logger, beaverStore);
 }
 
@@ -66,7 +67,7 @@ Future<int> _triggerHandler(
 }
 
 Future<int> triggerHandler(Trigger trigger, String projectId) async {
-  final context = _createContext();
+  final context = await _createContext();
 
   try {
     return await _triggerHandler(context, trigger, projectId);


### PR DESCRIPTION
This PR doesn't change BeaverStore to use GCloudStorageService, if you want to enable this change then see: https://github.com/joojis/beaver/commit/da94f33d4170f56417baa7435b1cbc427b452f6b

Please remember that GCLOUD_PROJECT_NAME is required to use GCloudStorageService, currently.
I think we should say about splitting the admin information(such as cloud_project_name) from beaver.yaml, then I can improve it.