### PR TITLE
Make projectName a local variable

### DIFF
--- a/beaver_cli/lib/src/cli_command/get_results.dart
+++ b/beaver_cli/lib/src/cli_command/get_results.dart
@@ -36,10 +36,10 @@ class GetResultsCommand extends HttpCommand {
   @override
   String get api => '/api/get-results';
 
-  String projectName;
-
   @override
   Future<Null> run() async {
+    String projectName;
+
     if (argResults.rest.length == 1) {
       projectName = argResults.rest[0];
     } else {


### PR DESCRIPTION
It is used only in GetResultsCommand.run method.