### PR TITLE
[task] Set allowTrailingOptions flag to false for GitTask.

### DIFF
--- a/beaver_task/lib/src/task/git_task.dart
+++ b/beaver_task/lib/src/task/git_task.dart
@@ -16,7 +16,7 @@ class GitTask extends Task {
       : this.processWorkingDir = processWorkingDir;
 
   factory GitTask.fromArgs(List<String> args) {
-    final parser = new ArgParser(allowTrailingOptions: true)
+    final parser = new ArgParser()
       ..addOption('process-working-dir', abbr: 'C');
     final results = parser.parse(args);
     return new GitTask(results.rest,


### PR DESCRIPTION
The trailing options need to be passed to runGit.